### PR TITLE
Fix Manifest#matches_all? by comparing array size instead of content

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    code_manifest (1.7.0)
+    code_manifest (1.7.1)
       psych (>= 4.0.0)
 
 GEM

--- a/code_manifest.gemspec
+++ b/code_manifest.gemspec
@@ -17,14 +17,9 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/rubyatscale/code_manifest"
   spec.metadata["changelog_uri"] = "https://github.com/rubyatscale/code_manifest/releases"
 
-  spec.files         = Dir["README.md", "lib/**/*"]
-  spec.require_paths = ["lib"]
+  spec.files = Dir["README.md", "lib/**/*"]
 
-  # Uncomment to register a new dependency of your gem
   spec.add_dependency "psych", ">= 4.0.0"
 
   spec.add_development_dependency 'rspec', '~> 3.0'
-
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
 end

--- a/lib/code_manifest/manifest.rb
+++ b/lib/code_manifest/manifest.rb
@@ -44,7 +44,7 @@ module CodeManifest
     end
 
     def matches_all?(paths)
-      matches(paths) == paths
+      matches(paths).size == paths.size
     end
 
     private

--- a/lib/code_manifest/version.rb
+++ b/lib/code_manifest/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CodeManifest
-  VERSION = '1.7.0'
+  VERSION = '1.7.1'
 end


### PR DESCRIPTION
Manifest#matches_all? was previously matching against the incoming array. If the incoming array is not sorted, then the `==` check will fail.