### PR TITLE
Dedup files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,4 +50,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.5.4
+   2.5.23

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    code_manifest (1.8.0)
+    code_manifest (1.9.0)
       psych (>= 4.0.0)
 
 GEM

--- a/lib/code_manifest/manifest.rb
+++ b/lib/code_manifest/manifest.rb
@@ -18,7 +18,7 @@ module CodeManifest
 
     def files
       @files ||= begin
-        matched_files = matches(Dir.glob(inclusion_rules.map(&:glob), GLOB_OPTIONS, base: CodeManifest.root))
+        matched_files = matches(Dir.glob(inclusion_rules.map(&:glob), GLOB_OPTIONS, base: CodeManifest.root)).uniq
         files_with_relative_path(matched_files).freeze
       end
     end

--- a/lib/code_manifest/version.rb
+++ b/lib/code_manifest/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CodeManifest
-  VERSION = '1.8.0'
+  VERSION = '1.9.0'
 end

--- a/spec/lib/code_manifest/manifest_spec.rb
+++ b/spec/lib/code_manifest/manifest_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe CodeManifest::Manifest do
       expect(manifest.files).to match_array(['bar/include', 'foo/foo.md'])
     end
 
+    context 'when there are duplicate patterns' do
+      let(:patterns) { ['/foo/foo.md', 'bar/*', '!bar/exclude', 'bar/*'] }
+
+      it 'dedups files' do
+        expect(manifest.files).to match_array(['bar/include', 'foo/foo.md'])
+      end
+    end
+
     context 'with different type of globs' do
       let(:patterns) { ['dir_bar/**/*'] }
       let(:manifest) { described_class.new(patterns) }


### PR DESCRIPTION
Current, `CodeManifest[:foo].files` returns duplicate files when there are duplicate globs/patterns. This is considered a bug and we should dedup them.