### PR TITLE
Add AGENTS.md and CLAUDE.md for AI coding agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
-# AGENTS.md
-
 This file provides guidance to AI coding agents when working with code in this repository.
 
 ## What this project is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents when working with code in this repository.
+
+## What this project is
+
+`code_manifest` is a Ruby gem that fetches files by glob patterns and generates a digest of those files. It is used to produce stable manifests of file sets for caching and change-detection purposes.
+
+## Commands
+
+```bash
+bundle install
+
+# Run all tests (RSpec)
+bundle exec rspec
+
+# Run a single spec file
+bundle exec rspec spec/path/to/spec.rb
+```
+
+## Architecture
+
+- `lib/code_manifest.rb` — public API; accepts glob patterns and returns matched files plus a digest
+- `lib/code_manifest/` — internal helpers for glob resolution and hashing
+- `spec/` — RSpec tests; `spec/fixtures/` holds sample file trees

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` with codebase guidance for AI coding agents (commands, architecture)
- Adds `CLAUDE.md` containing just `@AGENTS.md`, following the [Claude Code best practice](https://code.claude.com/docs/en/claude-code-on-the-web#best-practices) of sharing a single instruction file across agents

This makes the same guidance available to Claude Code (via `CLAUDE.md` import) and other agents like Codex that look for `AGENTS.md`.