### PR TITLE
Require Ruby >= 3.3 and update CI Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,8 @@ jobs:
       matrix:
         ruby:
           # See comment comes from https://github.com/ruby/setup-ruby#matrix-of-ruby-versions
-          # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-          - '3.0'
-          - 3.1
-          - 3.2
           - 3.3
+          - 3.4
           - head
     env:
       BUNDLE_GEMFILE: Gemfile

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,4 +50,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.5.23
+   4.0.15

--- a/code_manifest.gemspec
+++ b/code_manifest.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "A code manifest"
   spec.description = "A code manifest"
   spec.homepage = "https://github.com/rubyatscale/code_manifest"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.3")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/rubyatscale/code_manifest"


### PR DESCRIPTION
## Summary

Ruby 3.2 is now EOL. This PR raises the minimum supported Ruby to **3.3** and refreshes the CI test matrix to the supported set (**3.3** and **3.4**).

Motivation: resolve Ruby version restrictions from rubyatscale/pack_stats#56, where supporting EOL Ruby forced older/vulnerable transitive dependencies.

## Changes

- **`code_manifest.gemspec`**: `required_ruby_version` raised from `>= 2.7` to `>= 3.3` (preserving the `Gem::Requirement.new` style).
- **`.github/workflows/ci.yml`**: RSpec matrix now tests `3.3` and `3.4` (dropped EOL `3.0`, `3.1`, `3.2`); `head` retained. Removed the now-stale `'3.0'` quoting comment.

## Notes

- No `bundle install` was run and `Gemfile.lock` is unchanged.
- `push_gem.yml` (`ruby-version: ruby`) is intentionally left unchanged.
- Latest stable Ruby is 3.4.9; 3.5 is preview-only and not included.



## Bundler

Also bumps `BUNDLED WITH` in `Gemfile.lock` to bundler **4.0.15** (latest). The previously pinned bundler version crashes on Ruby `head` (`NameError: uninitialized constant Pathname::SEPARATOR_PAT`) — see [this failing run](https://github.com/rubyatscale/code_manifest/actions/runs/28200903631/job/83539858239?pr=12). Pinning the current bundler resolves it.