### PR TITLE
ci: test against Ruby 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         ruby:
           # See comment comes from https://github.com/ruby/setup-ruby#matrix-of-ruby-versions
-          - 3.3
-          - 3.4
-          - head
+          - '3.3'
+          - '3.4'
+          - '4.0'
     env:
       BUNDLE_GEMFILE: Gemfile
     name: "Tests: Ruby ${{ matrix.ruby }}"


### PR DESCRIPTION
## What
Adds **Ruby 4.0** to the CI build matrix so this gem is tested against the latest Ruby.

## Changes
- Add `'4.0'` to the test matrix.
- Remove `head` from the matrix.
- Quote all Ruby version numbers (`'3.3'`, `'3.4'`, `'4.0'`) for consistency and to avoid YAML float coercion.

## Why
Most rubyatscale repos already test Ruby 4.0 (via the shared reusable CI workflow). This brings the remaining custom-matrix repos in line.
