### PR TITLE
Drop explicit psych dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     code_manifest (1.9.0)
-      psych (>= 4.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/code_manifest.gemspec
+++ b/code_manifest.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["README.md", "lib/**/*"]
 
-  spec.add_dependency "psych", ">= 4.0.0"
-
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'debug'
 end


### PR DESCRIPTION
## Summary
- Removes the `spec.add_dependency "psych", ">= 4.0.0"` line from `code_manifest.gemspec`.
- Regenerates `Gemfile.lock` accordingly.

Psych ships as a default gem starting with Ruby 3.2, and this gemspec already requires Ruby >= 3.3, so declaring it as an explicit runtime dependency is unnecessary. `lib/code_manifest.rb` still does `require 'yaml'`, which continues to work as-is since `yaml` is itself a bundled default library that loads Psych internally. See [ruby/rdoc#1725](https://github.com/ruby/rdoc/pull/1725) for the same change made upstream in rdoc.

## Test plan
- [x] `bundle exec rspec` passes (19 examples, 0 failures)
- [x] `bundle check` confirms dependencies are satisfied